### PR TITLE
dsp的json和pb协议增加原生广告返回的deeplink相关参数

### DIFF
--- a/doc_in_chinese/rtb_protocol_json.md
+++ b/doc_in_chinese/rtb_protocol_json.md
@@ -367,7 +367,7 @@ Zplay Adx RTB 总共包含三个步骤：
 | action             | int      | 1      | 否   | 广告动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接， 3：打开地图，4：拨打电话，5：播放视频， 6：App下载，7：应用唤醒         |
 | download_file_name | string   |        | 否   | 下载文件名，动作类型为下载类型时需要                                                                                                               |
 | fallback_url       | string   |        | 否   | 应用唤醒失败后的打开地址，允许使用[宏](supported_macros.md)，例http://www.zplay.cn/ad/{AUCTION_BID_ID}                                             |
-| fallback_action    | int      | 1      | 否   | fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载；7：应用唤醒 |
+| fallback_action    | int      | 1      | 否   | fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载，7：应用唤醒 |
 
 **原生广告AdmOneof**
 
@@ -423,12 +423,15 @@ Zplay Adx RTB 总共包含三个步骤：
 | url           | string |        | 是   | 点击URL            |
 | clicktrackers | array  |        | 否   | 点击跟踪URL        |
 | ext           | object |        | 否   | 原声广告Link的扩展 |
+| fallback  | string |        | 否   | 应用唤醒失败后的打开地址，允许使用[宏](supported_macros.md)，例http://www.zplay.cn/ad/{AUCTION_BID_ID}|
+
 
 **原生广告Link扩展（NativeResponse.Asset.Link.Ext)**
 
 | 字段名称  | 类型 | 默认值 | 必须 | 描述                                                                                                                               |
 | --------- | ---- | ------ | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| link_type | int  |        | 否   | 广告动作类型， 1： 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接， 3：打开地图，4： 拨打电话，5：播放视频， 6：App下载 |
+| link_type | int  |        | 否   | 广告动作类型， 1： 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接， 3：打开地图，4： 拨打电话，5：播放视频， 6：App下载 ，7：应用唤醒|
+| fallback_action | int  | 1      | 否   | fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载，7：应用唤醒 |
 
 ## 向DSP发送的竞价结果接口(Win Notice)
 

--- a/doc_in_chinese/rtb_protocol_pb.md
+++ b/doc_in_chinese/rtb_protocol_pb.md
@@ -316,8 +316,8 @@ Zplay Adx RTB 总共包含三个步骤。
 | extensions[desc]               | string   |        | 否   | 图文广告中的描述                                                                                                                                                                                          |
 | extensions[action]             | int      | 1      | 否   | 广告动作类型， 1： 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接， 3：打开地图，4： 拨打电话，5：播放视频，6：App下载                                                                         |
 | extensions[download_file_name] | string   |        | 否   | 下载文件名，动作类型为下载类型时需要                                                                                                                                                                      |
-| extensions[fallback_url]       | string   |        | 否   | 应用唤醒失败后的打开地址，允许使用[宏](supported_macros.md)，例http://www.zplay.cn/ad/{AUCTION_BID_ID}                                                                                                    |
-| extensions[fallback_action]    | int      | 1      | 否   | fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载；7：应用唤醒                                                        |
+| extensions[fallback_url]       | string   |        | 否   | 应用唤醒失败后的打开地址，允许使用[宏](supported_macros.md)，例http://www.zplay.cn/ad/{AUCTION_BID_ID}                                                                                                             |
+| extensions[fallback_action]    | int      | 1      | 否   | fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载，7：应用唤醒                                                        |
 
 ##### 原生广告Native（NativeResponse）
 
@@ -362,9 +362,11 @@ Zplay Adx RTB 总共包含三个步骤。
 
 | 字段名称              | 类型   | 默认值 | 必须 | 描述                                                                                                                               |
 | --------------------- | ------ | ------ | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| url                   | string |        | 是   | 点击URL                                                                                                                            |
-| clicktrackers         | array  |        | 否   | 点击跟踪URL                                                                                                                        |
-| extensions[link_type] | int    |        | 是   | 广告动作类型， 1： 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接， 3：打开地图，4： 拨打电话，5：播放视频， 6：App下载 |
+| url                   | string |        | 是   | 点击URL |
+| clicktrackers         | array  |        | 否   | 点击跟踪URL |
+| fallback  | string |        | 否   | 应用唤醒失败后的打开地址，允许使用[宏](supported_macros.md)，例http://www.zplay.cn/ad/{AUCTION_BID_ID}|
+| extensions[link_type] | int    |        | 是   | 广告动作类型， 1： 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接， 3：打开地图，4： 拨打电话，5：播放视频， 6：App下载，7：应用唤醒 |
+| extensions[fallback_url_action]|int| | 否 |fallback_url的动作类型，1：在app内webview打开目标链接，2：在系统浏览器打开目标链接，3：打开地图，4：拨打电话，5：播放视频，6：App下载，7：应用唤醒 |
 
 ## 向DSP发送的竞价结果接口(Win Notice)
 

--- a/doc_in_english/rtb_protocol_json.md
+++ b/doc_in_english/rtb_protocol_json.md
@@ -428,6 +428,7 @@ There are three steps in RTB processing:
 | ------------- | ------ | ------------- | --------- | ------------------------------------------------------------------------- |
 | url           | string |               | yes       | target URL which is the jumping URL when user tap the corresponding asset |
 | clicktrackers | array  |               | no        | click tracking URL                                                        |
+| fallback      | string |               | no        | jumping url that when arousing app failed, allows to use macros [macro](supported_macros.md), for example, http://www.zplay.cn/ad/{AUCTION_BID_ID} |
 | ext           | object |               | no        | extension of link                                                         |
 
 **NativeResponse.Asset.Link.Ext**
@@ -435,6 +436,7 @@ There are three steps in RTB processing:
 | parameter | type | default value | mandatory | description                                                                                                                                                              |
 | --------- | ---- | ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | link_type | int  |               | no        | action type of target url, 1: open the clkurl within webview in-app, 2: open the clkurl within system browser, 3: open map, 4: open dial, 5: play video, 6: download App |
+| fallback_action    | int      |             | no        | action type of fallback_url, 1: open the clkurl within webview in-app, 2: open the clkurl within system browser, 3: open map, 4: open dial, 5: play video, 6: download App, 7: arouse App |
 
 ## Win Notice
 

--- a/doc_in_english/rtb_protocol_pb.md
+++ b/doc_in_english/rtb_protocol_pb.md
@@ -356,9 +356,9 @@ There are three steps in RTB processing:
 | ------------- | ------ | ------------- | --------- | ------------------------------------------------------------------------- |
 | url           | string |               | yes       | target URL which is the jumping URL when user tap the corresponding asset |
 | clicktrackers | array  |               | no        | click tracking URL                                                        |
-
-| extensions[link_type] | int    |               | 是        | types of link, 1: open the clkurl within webview in-app, 2: open the clkurl within system browser, 3: open map, 4: open dial, 5: play video, 6: download App, 7: arouse App |
-
+| fallback      | string |               | no        | jumping url that when arousing app failed, allows to use macros [macro](supported_macros.md), for example, http://www.zplay.cn/ad/{AUCTION_BID_ID} |
+| extensions[link_type]  | int |         | no        | types of link, 1: open the clkurl within webview in-app, 2: open the clkurl within system browser, 3: open map, 4: open dial, 5: play video, 6: download App, 7: arouse App |
+| extensions[fallback_url_action]|int| 1  |no         |action type of fallback_url, 1: open the clkurl within webview in-app, 2: open the clkurl within system browser, 3: open map, 4: open dial, 5: play video, 6: download App, 7: arouse App |
 ## Win Notice
 
 sending the billable info to DSP that win the auction through substitute the macro of imptrackers.

--- a/zplay_adx_rtb.proto
+++ b/zplay_adx_rtb.proto
@@ -36,7 +36,10 @@ extend zadx.BidRequest.Imp {
 
     // 广告类型，0:banner，1:插屏，2:开屏，3:原生，4:视频
     optional int32 ad_type = 202;
-}
+    
+    // 广告位名称，tagid为广告位ID
+    optional string tag_name = 203;
+    }
 
 extend zadx.BidRequest.Device {
     // 国家运营商编号
@@ -89,7 +92,7 @@ extend zadx.BidResponse.SeatBid.Bid {
   // 图文广告中的描述
   optional string desc = 207;
 
-  // 广告动作类型， 1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载
+  // 广告动作类型， 1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载, 7:deeplink唤醒
   optional int32 action = 208;
 
   // 下载文件名，动作类型为下载类型时需要
@@ -99,12 +102,24 @@ extend zadx.BidResponse.SeatBid.Bid {
   repeated string play_start_trackers = 210;
   // 可玩式广告的结束播放追踪链接
   repeated string play_end_trackers = 211;
+  
+  // 唤醒链接失败后调用的该url跳转
+  optional string fallback_url = 212;
+
+  // fallback_url对应的点击操作类型,1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载
+  optional int32 fallback_action = 213;
 }
 
 extend zadx.NativeResponse.Link {
-  // 链接动作类型, 1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载
+  // 链接动作类型, 1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载, 7:deeplink唤醒
   optional int32 link_type = 200;
-}
+
+  // 唤醒链接失败后调用的该url跳转
+  optional string fallback = 201;
+
+  // fallback_url对应的点击操作类型,1: 在app内webview打开目标链接， 2： 在系统浏览器打开目标链接, 3：打开地图，4： 拨打电话，5：播放视频, 6:App下载
+  optional int32 fallback_url_action = 202;
+  }
 
 
 


### PR DESCRIPTION
dsp response协议中的native广告返回时，native.link对象里的fallback参数名，而不是fallback_url，是因为Open RTB 规范里原生就有fallback参数，用来支持deeplink的。
我们对于这次更新，就是多了一个fallback_url_action参数，放在了native.link.ext对象中。并且该参数名不是fallback_action是因为pb协议里不允许同名参数。